### PR TITLE
Remove no-empty-source rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,6 @@ module.exports = {
     "media-query-list-comma-newline-after": "always-multi-line",
     "media-query-list-comma-space-after": "always-single-line",
     "media-query-list-comma-space-before": "never",
-    "no-empty-source": true,
     "no-eol-whitespace": true,
     "no-invalid-double-slash-comments": true,
     "number-no-trailing-zeros": true,


### PR DESCRIPTION
In the latest release https://github.com/stylelint/stylelint/releases/tag/9.2.0 they fixed `no-empty-source` false positives, and now our linter is failing

Example of failing build: https://travis-ci.org/vaadin/vaadin-overlay/jobs/370444129

The reason for failing: https://github.com/vaadin/vaadin-overlay/blob/e9f7f21ffa7e72114a468da9578aa413f7d8aed5/demo/common.html#L4-L6

---

This PR removes `no-empty-source` rule because we are using empty `<style>` tags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/stylelint-config-vaadin/2)
<!-- Reviewable:end -->
