### PR TITLE
Bump stylelint peer dependency to 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "index.js"
   ],
   "peerDependencies": {
-    "stylelint": "^8.0.0"
+    "stylelint": "^9.0.0"
   }
 }


### PR DESCRIPTION
We have already updated all the components but forgot to bump this dependency here.
Sending the PR to get rid of the npm warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/stylelint-config-vaadin/3)
<!-- Reviewable:end -->
