### PR TITLE
Update to new config & processor for LitElement

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,19 @@
 "use strict";
 
 module.exports = {
+  "processors": [
+    [
+      "stylelint-processor-styled-components",
+      {
+        "moduleName": "@vaadin/vaadin-themable-mixin",
+        "importName": "css",
+        "strict": true
+      }
+    ]
+  ],
+  "extends": [
+    "stylelint-config-styled-components"
+  ],
   "rules": {
     "at-rule-name-case": "lower",
     "at-rule-name-space-after": "always-single-line",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
   "files": [
     "index.js"
   ],
+  "dependencies": {
+    "stylelint-config-styled-components": "^0.1.0",
+    "stylelint-processor-styled-components": "^1.8.0"
+  },
   "peerDependencies": {
-    "stylelint": "^9.0.0"
+    "stylelint": "^11.0.0"
   }
 }


### PR DESCRIPTION
Added [stylelint-processor-styled-components](https://github.com/styled-components/stylelint-processor-styled-components) to lint CSS inside of the tagged `css` literals.

This works with both `lit-element` and `@vaadin/vaadin-themable-mixin` (despite the `moduleName` setting). Any other literals except `css` should be excluded (via `strict` option).