### PR TITLE
chore: add mask-size to the list of allowed vendor prefixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = {
           'text-size-adjust',
           'tab-size',
           'mask-position',
+          'mask-size',
         ],
       },
     ],


### PR DESCRIPTION
## Description

This is needed to fix the following warning reported in https://github.com/vaadin/web-components/pull/8146

```
packages/avatar-group/src/vaadin-avatar-group-styles.js
  30:5  ✖  Unexpected vendor-prefix "-webkit-mask-size"  property-no-vendor-prefix
```

Prefix is still needed for Safari up until 15.3: https://caniuse.com/mdn-css_properties_mask-size

## Type of change

- Configuration update